### PR TITLE
FIXED: garbage displayed when charCode === 173, fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class HexaFile {
         this.statFile(this.path);
         this.checkStartOffset();
         this.fd = fs.openSync(this.path, 'r');
-        this.buffer = new Buffer(BUFFER_LENGTH);
+        this.buffer = Buffer.alloc(BUFFER_LENGTH);
         this.readChunk(this.currentOffset);
     }
 
@@ -209,7 +209,8 @@ class HexaFile {
         // Most Windows command line tools (eg. more) do not properly handle utf8
         // so we do not print extended ascci chars (code > 160)
         // on this platform, this allows to use `ch foo.zip | more` safely
-        if ((!isWindows && code > 160) || (code >= 32 && code < 127)) {
+        // Also skip 0xAD which doesn't seem to be a valid character
+        if (((!isWindows && code > 160) || (code >= 32 && code < 127)) && code !== 0xAD) {
             return String.fromCharCode(code);
         } else {
             return '.';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cat-hex",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/warpdesign/cat-hex.git"
@@ -10,7 +10,7 @@
     "hexadecimal",
     "binary",
     "viewer"
-  ],  
+  ],
   "description": "shows content of binary files - the cat of hexadecimal",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
UPDATED: don't use Buffer constructor which is deprecated